### PR TITLE
fix: removed initialization of unused object to fix innacurate benchm…

### DIFF
--- a/src/main/java/com/github/fabienrenaud/jjb/stream/UsersStreamSerializer.java
+++ b/src/main/java/com/github/fabienrenaud/jjb/stream/UsersStreamSerializer.java
@@ -109,7 +109,6 @@ public class UsersStreamSerializer implements StreamSerializer<Users> {
     @Override
     public void javaxjson(final javax.json.stream.JsonGenerator generator, final Users obj) throws IOException {
         generator.writeStartObject();
-        javax.json.JsonObjectBuilder jso = javax.json.Json.createObjectBuilder();
         if (obj.users != null) {
             generator.writeStartArray("users");
             for (User u : obj.users) {


### PR DESCRIPTION
The instantiation of JsonObjectBuilder _jso_ compromises the results for javaxjson in the Users serialization benchmark.

Before fix:
<html>
<body>
<!--StartFragment--><google-sheets-html-origin><style type="text/css"><!--td {border: 1px solid #ccc;}br {mso-data-placement:same-cell;}--></style>

Throughput (ops/s) | 37440 | 26722 | 10831 | 1314
-- | -- | -- | -- | --
Min | 30600 | 22509 | 9706 | 1098
Max | 40305 | 29900 | 11690 | 1662
StDev | 2610 | 2617 | 588 | 149
Error | 2266 | 2273 | 511 | 129

<!--EndFragment-->
</body>
</html>
After fix:
<html>
<body>
<!--StartFragment--><google-sheets-html-origin><style type="text/css"><!--td {border: 1px solid #ccc;}br {mso-data-placement:same-cell;}--></style>

After applying fix |   |   |   |  
-- | -- | -- | -- | --
Throughput (ops/s) | 927220 | 128001 | 13081 | 1343
Min | 851887 | 99382 | 11443 | 1038
Max | 968224 | 161237 | 17228 | 1625
StDev | 28860 | 11854 | 1351 | 148
Error | 25061 | 10294 | 1173 | 129

<!--EndFragment-->
</body>

</html>[fix_profile_users_ser_javaxjson_1kb.log](https://github.com/fabienrenaud/java-json-benchmark/files/7758015/fix_profile_users_ser_javaxjson_1kb.log)
[profile_users_ser_javaxson_1kb.log](https://github.com/fabienrenaud/java-json-benchmark/files/7758016/profile_users_ser_javaxson_1kb.log)

Some post-fix results for all payloads:
[users-ser-1.csv](https://github.com/fabienrenaud/java-json-benchmark/files/7758067/users-ser-1.csv)
[users-ser-1-1.txt](https://github.com/fabienrenaud/java-json-benchmark/files/7758069/users-ser-1-1.txt)
[users-ser-1-10.txt](https://github.com/fabienrenaud/java-json-benchmark/files/7758070/users-ser-1-10.txt)
[users-ser-1-100.txt](https://github.com/fabienrenaud/java-json-benchmark/files/7758071/users-ser-1-100.txt)
[users-ser-1-1000.txt](https://github.com/fabienrenaud/java-json-benchmark/files/7758072/users-ser-1-1000.txt)

