### PR TITLE
Bump to Java 11

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,8 +9,8 @@ group = 'com.github.fabienrenaud'
 version = '7'
 mainClassName = 'com.github.fabienrenaud.jjb.Cli'
 
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+sourceCompatibility = 11
+targetCompatibility = 11
 
 repositories {
     jcenter()

--- a/run
+++ b/run
@@ -3,7 +3,7 @@
 JAR=build/libs/app.jar
 HEAP_SIZE=2g
 
-[ -z ${JVM_OPTIONS} ] && JVM_OPTIONS="-server -XX:+AggressiveOpts -Xms${HEAP_SIZE} -Xmx${HEAP_SIZE}"
+[ -z ${JVM_OPTIONS} ] && JVM_OPTIONS="-server -Xms${HEAP_SIZE} -Xmx${HEAP_SIZE}"
 [ -z ${SEED} ] && export SEED=${RANDOM}
 [ -z ${SHADOW} ] && echo ./gradlew clean build shadowJar && ./gradlew clean build shadowJar
 


### PR DESCRIPTION
JVM option `+AggressiveOpts` is not supported with Java 11

```
./run -t 8 ser --apis databind --libs dsljson,jackson,avajejsonb
...

Benchmark                           Mode  Cnt        Score        Error  Units
Serialization.avajejsonb           thrpt   20  1585076.847 ±  36652.798  ops/s
Serialization.avajejsonb_jackson   thrpt   20  1213119.133 ±  38043.554  ops/s
Serialization.dsljson              thrpt   20  2105699.862 ± 170635.410  ops/s
Serialization.dsljson_reflection   thrpt   20  1222861.457 ± 183719.804  ops/s
Serialization.jackson              thrpt   20   849187.430 ±  36890.232  ops/s
Serialization.jackson_afterburner  thrpt   20   918967.302 ±  20334.650  ops/s
```

```
./run -t 8 deser --apis databind --libs dsljson,jackson,avajejsonb
...

Benchmark                             Mode  Cnt       Score        Error  Units
Deserialization.avajejsonb           thrpt   20  868045.014 ±  17977.578  ops/s
Deserialization.avajejsonb_jackson   thrpt   20  584279.347 ±  19173.005  ops/s
Deserialization.dsljson              thrpt   20  890778.545 ± 117956.756  ops/s
Deserialization.dsljson_reflection   thrpt   20  717535.068 ±  78193.330  ops/s
Deserialization.jackson              thrpt   20  594409.019 ±  22062.293  ops/s
Deserialization.jackson_afterburner  thrpt   20  709780.268 ±  22885.685  ops/s
```