### PR TITLE
Bump avaje-jsonb to 1.0-RC4

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ It covers the following libraries:
 * [json-smart](http://netplex.github.io/json-smart/)
 * [johnzon](http://johnzon.apache.org/)
 * [logansquare](https://github.com/bluelinelabs/LoganSquare)
+* [avaje-jsonb](https://github.com/avaje/avaje-jsonb)
 * [dsl-json](https://github.com/ngs-doo/dsl-json)
 * [json-simple](https://code.google.com/archive/p/json-simple/)
 * [nanojson](https://github.com/mmastrac/nanojson)

--- a/build.gradle
+++ b/build.gradle
@@ -87,9 +87,9 @@ dependencies {
     // purejson
     implementation group: 'io.github.senthilganeshs', name: 'purejson', version: '1.0.1'
     // avaje-jsonb
-    implementation group: 'io.avaje', name: 'avaje-jsonb', version: '0.11'
-    implementation group: 'io.avaje', name: 'avaje-jsonb-jackson', version: '0.11'
-    annotationProcessor group: 'io.avaje', name: 'avaje-jsonb-generator', version: '0.11'
+    implementation group: 'io.avaje', name: 'avaje-jsonb', version: '1.0-RC4'
+    implementation group: 'io.avaje', name: 'avaje-jsonb-jackson', version: '1.0-RC4'
+    annotationProcessor group: 'io.avaje', name: 'avaje-jsonb-generator', version: '1.0-RC4'
 
     // Test
     testImplementation group: 'junit', name: 'junit', version: '4.13.2'


### PR DESCRIPTION
Bumps the version of avaje-jsonb to 1.0-RC4

Local serialization benchmark with avajejsonb and jackson:
```
Benchmark                                            Mode  Cnt        Score       Error  Units
c.g.f.j.databind.Serialization.avajejsonb           thrpt   20  1666120.113 ± 63817.274  ops/s
c.g.f.j.databind.Serialization.avajejsonb_jackson   thrpt   20  1458963.936 ±  7344.273  ops/s
c.g.f.j.databind.Serialization.jackson              thrpt   20  1356579.031 ± 62725.403  ops/s
c.g.f.j.databind.Serialization.jackson_afterburner  thrpt   20  1558020.732 ± 44209.328  ops/s
c.g.f.j.databind.Serialization.jackson_blackbird    thrpt   20  1386688.051 ± 28723.710  ops/s
c.g.f.j.stream.Serialization.jackson                thrpt   20  1448220.803 ±  7608.611  ops/s
```

Local deserialization benchmark with avajejsonb and jackson:
```
Benchmark                                              Mode  Cnt        Score       Error  Units
c.g.f.j.databind.Deserialization.avajejsonb           thrpt   20  1246213.390 ± 24483.890  ops/s
c.g.f.j.databind.Deserialization.avajejsonb_jackson   thrpt   20   842621.313 ± 44883.536  ops/s
c.g.f.j.databind.Deserialization.jackson              thrpt   20   724829.997 ± 13937.611  ops/s
c.g.f.j.databind.Deserialization.jackson_afterburner  thrpt   20   911874.821 ± 41527.068  ops/s
c.g.f.j.databind.Deserialization.jackson_blackbird    thrpt   20   795688.913 ± 22670.633  ops/s
c.g.f.j.stream.Deserialization.jackson                thrpt   20   811412.445 ± 39685.062  ops/s
```
