### PR TITLE
Upgrade underscore library

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -83,7 +83,7 @@ dependencies {
     // mjson
     implementation group: 'org.sharegov', name: 'mjson', version: '1.4.1'
     // underscore-java
-    implementation group: 'com.github.javadev', name: 'underscore', version: '1.71'
+    implementation group: 'com.github.javadev', name: 'underscore', version: '1.81'
     // purejson
     implementation group: 'io.github.senthilganeshs', name: 'purejson', version: '1.0.1'
     // avaje-jsonb

--- a/src/main/java/com/github/fabienrenaud/jjb/stream/UsersStreamDeserializer.java
+++ b/src/main/java/com/github/fabienrenaud/jjb/stream/UsersStreamDeserializer.java
@@ -711,7 +711,7 @@ public class UsersStreamDeserializer implements StreamDeserializer<Users> {
 
     @Override
     public Users underscore_java(String string) {
-        Map<String, Object> jso = com.github.underscore.lodash.U.fromJson(string);
+        Map<String, Object> jso = com.github.underscore.U.fromJson(string);
         Object v;
         Users uc = new Users();
 

--- a/src/main/java/com/github/fabienrenaud/jjb/stream/UsersStreamSerializer.java
+++ b/src/main/java/com/github/fabienrenaud/jjb/stream/UsersStreamSerializer.java
@@ -1078,7 +1078,7 @@ public class UsersStreamSerializer implements StreamSerializer<Users> {
             }
             jso.put("users", jsarr);
         }
-        return com.github.underscore.lodash.U.toJson(jso);
+        return com.github.underscore.U.toJson(jso);
     }
 
     private Map<String, Object> underscore_java(User u) throws IOException {


### PR DESCRIPTION
Only using 1.81 (not the latest 1.82 which requires Java 11).

The classes have been moved between packages inside the library.

see https://github.com/javadev/underscore-java/releases