### PR TITLE
Upgrade libraries

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,48 +17,48 @@ repositories {
 }
 
 ext {
-    jacksonVersion = '2.13.0'
+    jacksonVersion = '2.13.4'
     dslJsonVersion = '1.9.9'
-    johnzonVersion = '1.2.15'
-    jmhVersion = '1.33'
+    johnzonVersion = '1.2.19'
+    jmhVersion = '1.35'
 }
 
 dependencies {
 
     // CLI and misc
     implementation group: 'io.airlift', name: 'airline', version: '0.9'
-    implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.9'
+    implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.12.0'
 
     // org.json
-    implementation group: 'org.json', name: 'json', version: '20210307'
+    implementation group: 'org.json', name: 'json', version: '20220924'
     // Jackson
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: "${jacksonVersion}"
     implementation group: 'com.fasterxml.jackson.module', name: 'jackson-module-afterburner', version: "${jacksonVersion}"
     implementation group: 'com.fasterxml.jackson.module', name: 'jackson-module-blackbird', version: "${jacksonVersion}"
     implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: "${jacksonVersion}"
     // GSON
-    implementation group: 'com.google.code.gson', name: 'gson', version: '2.8.9'
+    implementation group: 'com.google.code.gson', name: 'gson', version: '2.10'
     // JSONP
     implementation group: 'javax.json', name: 'javax.json-api', version: '1.1.4'
     implementation group: 'org.glassfish', name: 'javax.json', version: '1.1.4'
     // JSONB
     implementation group: 'javax.json.bind', name: 'javax.json.bind-api', version: '1.0'
-    implementation group: 'org.eclipse', name: 'yasson', version: '1.0.9'
+    implementation group: 'org.eclipse', name: 'yasson', version: '1.0.11'
     // GENSON
     implementation group: 'com.owlike', name: 'genson', version: '1.6'
     // FlexJson
     implementation group: 'net.sf.flexjson', name: 'flexjson', version: '3.3'
     // FastJson
-    implementation group: 'com.alibaba', name: 'fastjson', version: '1.2.78'
+    implementation group: 'com.alibaba', name: 'fastjson', version: '1.2.83'
     // json-io
-    implementation group: 'com.cedarsoftware', name: 'json-io', version: '4.13.0'
+    implementation group: 'com.cedarsoftware', name: 'json-io', version: '4.14.0'
     // boon
     implementation group: 'io.fastjson', name: 'boon', version: '0.34'
     // johnzon
     implementation group: 'org.apache.johnzon', name: 'johnzon-core', version: "${johnzonVersion}"
     implementation group: 'org.apache.johnzon', name: 'johnzon-mapper', version: "${johnzonVersion}"
     // json-smart
-    implementation group: 'net.minidev', name: 'json-smart', version: '2.4.7'
+    implementation group: 'net.minidev', name: 'json-smart', version: '2.4.8'
     // DSL-json
     implementation group: 'com.dslplatform', name: 'dsl-json-java8', version: "${dslJsonVersion}"
     annotationProcessor group: 'com.dslplatform', name: 'dsl-json-java8', version: "${dslJsonVersion}"
@@ -72,12 +72,12 @@ dependencies {
     // jodd
     implementation group: 'org.jodd', name: 'jodd-json', version: '6.0.3'
     // moshi
-    implementation group: 'com.squareup.moshi', name: 'moshi', version: '1.12.0'
+    implementation group: 'com.squareup.moshi', name: 'moshi', version: '1.14.0'
     // tapestry
-    implementation group: 'org.apache.tapestry', name: 'tapestry-json', version: '5.7.3'
+    implementation group: 'org.apache.tapestry', name: 'tapestry-json', version: '5.8.2'
     // jsoniter
     implementation group: 'com.jsoniter', name: 'jsoniter', version: '0.9.23'
-    implementation group: 'org.javassist', name: 'javassist', version: '3.26.0-GA'
+    implementation group: 'org.javassist', name: 'javassist', version: '3.29.2-GA'
     // minimal-json
     implementation group: 'com.eclipsesource.minimal-json', name: 'minimal-json', version: '0.9.5'
     // mjson


### PR DESCRIPTION
The following upgrades are available too. But they contain breaking changes. Therefore they are not included here.

- yasson: 2.0.4 or 3.0.2
- fastjson: 2.0.17
- underscore: 1.82