### PR TITLE
Upgrade to JDK 17

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,8 +9,8 @@ group = 'com.github.fabienrenaud'
 version = '7'
 mainClassName = 'com.github.fabienrenaud.jjb.Cli'
 
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+sourceCompatibility = 17
+targetCompatibility = 17
 
 repositories {
     mavenCentral()

--- a/run
+++ b/run
@@ -3,7 +3,7 @@
 JAR=build/libs/app.jar
 HEAP_SIZE=2g
 
-[ -z ${JVM_OPTIONS} ] && JVM_OPTIONS="-server -XX:+AggressiveOpts -Xms${HEAP_SIZE} -Xmx${HEAP_SIZE}"
+[ -z ${JVM_OPTIONS} ] && JVM_OPTIONS="-server -Xms${HEAP_SIZE} -Xmx${HEAP_SIZE}"
 [ -z ${SEED} ] && export SEED=${RANDOM}
 [ -z ${SHADOW} ] && echo ./gradlew clean build shadowJar && ./gradlew clean build shadowJar
 

--- a/src/main/java/com/github/fabienrenaud/jjb/support/Libapi.java
+++ b/src/main/java/com/github/fabienrenaud/jjb/support/Libapi.java
@@ -4,52 +4,12 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 
-public class Libapi {
-
-    private final boolean active;
-    private final Library lib;
-    private final List<Api> api;
-
+public record Libapi(boolean active, Library lib, List<Api> api) {
     public Libapi(Library lib, Api... api) {
         this(true, lib, api);
     }
 
     public Libapi(boolean active, Library lib, Api... api) {
-        this.active = active;
-        this.lib = lib;
-        this.api = Arrays.asList(api);
-    }
-
-    public boolean active() {
-        return active;
-    }
-
-    public Library lib() {
-        return lib;
-    }
-
-    public List<Api> api() {
-        return api;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (!(o instanceof Libapi)) {
-            return false;
-        }
-
-        Libapi libapi = (Libapi) o;
-
-        return active == libapi.active &&
-                lib == libapi.lib &&
-                Objects.equals(api, libapi.api);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(active, lib, api);
+        this(active, lib, Arrays.asList(api));
     }
 }


### PR DESCRIPTION
Upgrades the suite to use JDK 17. Required removing the `-XX:+AggressiveOpts` option from the launcher since that has been removed.