### PR TITLE
Remove AggressiveOpts

### DIFF
--- a/run
+++ b/run
@@ -3,7 +3,7 @@
 JAR=build/libs/app.jar
 HEAP_SIZE=2g
 
-[ -z ${JVM_OPTIONS} ] && JVM_OPTIONS="-server -XX:+AggressiveOpts -Xms${HEAP_SIZE} -Xmx${HEAP_SIZE}"
+[ -z ${JVM_OPTIONS} ] && JVM_OPTIONS="-server -Xms${HEAP_SIZE} -Xmx${HEAP_SIZE}"
 [ -z ${SEED} ] && export SEED=${RANDOM}
 [ -z ${SHADOW} ] && echo ./gradlew clean build shadowJar && ./gradlew clean build shadowJar
 


### PR DESCRIPTION
Remove AggressiveOpts, it is no longer supported on the latest Java versions.

AggressiveOpts have been removed in JDK 12 by [JDK-8150552](https://bugs.openjdk.org/browse/JDK-8150552) with the reasoning

> `-XX:+AggressiveOpts` has been used as a catch-all method of enabling various experimental performance features, mostly targetted to improve score on very specific benchmarks. Most things it affected has been removed or integrated over time, e.g., [JDK-8024826](https://bugs.openjdk.org/browse/JDK-8024826), leaving the behavior of the flag ill-defined and prone to cause more issues than it'll solve.

I ran a check with `-XX:+PrintFlagsFinal` on JDK 11.0.17 and the only differences I could find were

| Flag  | Default | AggressiveOpts |
| :---    |        ---: |                      ---: |
| AutoBoxCacheMax  | 128  | 20000 |
| BiasedLockingStartupDelay  | 0  | 500 |

Note that `-server` is also questionable, to the best of my knowledge [64bit is always server class](https://docs.oracle.com/javase/8/docs/technotes/guides/vm/server-class.html)