### PR TITLE
Set default number of threads based on number of cores

### DIFF
--- a/src/main/java/com/github/fabienrenaud/jjb/Cli.java
+++ b/src/main/java/com/github/fabienrenaud/jjb/Cli.java
@@ -55,8 +55,8 @@ public final class Cli {
         public int measurementIterations = 10;
         @Option(type = OptionType.GLOBAL, name = "-m", description = "JMH: measurement time in seconds. Defaults to 3.")
         public int measurementTime = 3;
-        @Option(type = OptionType.GLOBAL, name = "-t", description = "JMH: number of threads. Defaults to 16.")
-        public int threads = 16;
+        @Option(type = OptionType.GLOBAL, name = "-t", description = "JMH: number of threads. Defaults to number of cores-1.")
+        public int threads = Math.max(Runtime.getRuntime().availableProcessors() - 1, 1);
 
         /*
          * JSON options


### PR DESCRIPTION
Using more threads than cores results in unnecessary context switches and will actually decrease throughput. I set the number of threads to the number cores minus 1 so the OS has one core to do other pressing things and does not need to congest the cores utilized by JMH.