### PR TITLE
Update test lib's

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ The results here-below were computed on January the 30th, 2024 with the followin
 | purejson     | 1.0.1    |
 | qson         | 1.1.1    |
 | tapestry     | 5.8.6    |
-| underscore   | 1.97     | 
+| underscore   | 1.101    | 
 | yasson       | 3.0.3    |
 | wast         | 0.0.12.1 |
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ The results here-below were computed on January the 30th, 2024 with the followin
 | jodd json    | 6.0.3    |
 | johnzon      | 1.2.21   |
 | jakarta      | 2.1.3    |
-| json-io      | 4.14.0   |
+| json-io      | 4.24.0   |
 | simplejson   | 1.1.1    |
 | json-smart   | 2.5.1    |
 | logansquare  | 1.3.7    |

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ The results here-below were computed on January the 30th, 2024 with the followin
 | minimal-json | 0.9.5    |
 | mjson        | 1.4.1    |
 | moshi        | 1.15.1   |
-| nanojson     | 1.8      |
+| nanojson     | 1.9      |
 | org.json     | 20231013 |
 | purejson     | 1.0.1    |
 | qson         | 1.1.1    |

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ The results here-below were computed on January the 30th, 2024 with the followin
 | org.json     | 20240303 |
 | purejson     | 1.0.1    |
 | qson         | 1.1.1    |
-| tapestry     | 5.8.3    |
+| tapestry     | 5.8.6    |
 | underscore   | 1.97     | 
 | yasson       | 3.0.3    |
 | wast         | 0.0.12.1 |

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ The results here-below were computed on January the 30th, 2024 with the followin
 | jakarta      | 2.1.3    |
 | json-io      | 4.14.0   |
 | simplejson   | 1.1.1    |
-| json-smart   | 2.4.11   |
+| json-smart   | 2.5.1    |
 | logansquare  | 1.3.7    |
 | minimal-json | 0.9.5    |
 | mjson        | 1.4.1    |

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ The results here-below were computed on January the 30th, 2024 with the followin
 | logansquare  | 1.3.7    |
 | minimal-json | 0.9.5    |
 | mjson        | 1.4.1    |
-| moshi        | 1.15.0   |
+| moshi        | 1.15.1   |
 | nanojson     | 1.8      |
 | org.json     | 20231013 |
 | purejson     | 1.0.1    |

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ The results here-below were computed on January the 30th, 2024 with the followin
 | jodd json    | 6.0.3    |
 | johnzon      | 1.2.21   |
 | jakarta      | 2.1.3    |
-| json-io      | 4.40.0   |
+| json-io      | 4.14.0   |
 | simplejson   | 1.1.1    |
 | json-smart   | 2.4.11   |
 | logansquare  | 1.3.7    |

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ The results here-below were computed on January the 30th, 2024 with the followin
 |--------------|----------|
 | avaje-jsonb  | 1.11     |
 | boon         | 0.34     |
-| dsl-json     | 1.10.0   |
+| dsl-json     | 2.0.2    |
 | fastjson     | 2.0.46   |
 | flexjson     | 3.3      |
 | genson       | 1.6      |

--- a/README.md
+++ b/README.md
@@ -58,30 +58,30 @@ The results here-below were computed on January the 30th, 2024 with the followin
 
 | Library      | Version  |
 |--------------|----------|
-| avaje-jsonb  | 1.11     |
+| avaje-jsonb  | 1.9      |
 | boon         | 0.34     |
-| dsl-json     | 2.0.2    |
+| dsl-json     | 1.10.0   |
 | fastjson     | 2.0.46   |
 | flexjson     | 3.3      |
 | genson       | 1.6      |
-| gson         | 2.11.0   |
-| jackson      | 2.17.1   |
+| gson         | 2.10.1   |
+| jackson      | 2.16.0   |
 | jodd json    | 6.0.3    |
-| johnzon      | 2.0.1    |
+| johnzon      | 1.2.21   |
 | jakarta      | 2.1.3    |
 | json-io      | 4.24.0   |
 | simplejson   | 1.1.1    |
-| json-smart   | 2.5.1    |
+| json-smart   | 2.4.11   |
 | logansquare  | 1.3.7    |
 | minimal-json | 0.9.5    |
 | mjson        | 1.4.1    |
-| moshi        | 1.15.1   |
-| nanojson     | 1.9      |
-| org.json     | 20240303 |
+| moshi        | 1.15.0   |
+| nanojson     | 1.8      |
+| org.json     | 20231013 |
 | purejson     | 1.0.1    |
 | qson         | 1.1.1    |
-| tapestry     | 5.8.6    |
-| underscore   | 1.101    | 
+| tapestry     | 5.8.3    |
+| underscore   | 1.97     | 
 | yasson       | 3.0.3    |
 | wast         | 0.0.12.1 |
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ The results here-below were computed on January the 30th, 2024 with the followin
 | mjson        | 1.4.1    |
 | moshi        | 1.15.1   |
 | nanojson     | 1.9      |
-| org.json     | 20231013 |
+| org.json     | 20240303 |
 | purejson     | 1.0.1    |
 | qson         | 1.1.1    |
 | tapestry     | 5.8.3    |

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ The results here-below were computed on January the 30th, 2024 with the followin
 | gson         | 2.11.0   |
 | jackson      | 2.17.1   |
 | jodd json    | 6.0.3    |
-| johnzon      | 1.2.21   |
+| johnzon      | 2.0.1    |
 | jakarta      | 2.1.3    |
 | json-io      | 4.24.0   |
 | simplejson   | 1.1.1    |

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ The results here-below were computed on January the 30th, 2024 with the followin
 
 | Library      | Version  |
 |--------------|----------|
-| avaje-jsonb  | 1.9      |
+| avaje-jsonb  | 1.11     |
 | boon         | 0.34     |
 | dsl-json     | 1.10.0   |
 | fastjson     | 2.0.46   |

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ The results here-below were computed on January the 30th, 2024 with the followin
 | flexjson     | 3.3      |
 | genson       | 1.6      |
 | gson         | 2.10.1   |
-| jackson      | 2.16.0   |
+| jackson      | 2.17.1   |
 | jodd json    | 6.0.3    |
 | johnzon      | 1.2.21   |
 | jakarta      | 2.1.3    |

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ The results here-below were computed on January the 30th, 2024 with the followin
 | fastjson     | 2.0.46   |
 | flexjson     | 3.3      |
 | genson       | 1.6      |
-| gson         | 2.10.1   |
+| gson         | 2.11.0   |
 | jackson      | 2.17.1   |
 | jodd json    | 6.0.3    |
 | johnzon      | 1.2.21   |

--- a/build.gradle
+++ b/build.gradle
@@ -91,7 +91,7 @@ dependencies {
     // qson
     implementation group: 'io.quarkus.qson', name: 'qson-generator', version: '1.1.1.Final'
     // tapestry
-    implementation group: 'org.apache.tapestry', name: 'tapestry-json', version: '5.8.3'
+    implementation group: 'org.apache.tapestry', name: 'tapestry-json', version: '5.8.6'
     // underscore-java
     implementation group: 'com.github.javadev', name: 'underscore', version: '1.97'
     // yasson

--- a/build.gradle
+++ b/build.gradle
@@ -81,7 +81,7 @@ dependencies {
     // mjson
     implementation group: 'org.sharegov', name: 'mjson', version: '1.4.1'
     // moshi
-    implementation group: 'com.squareup.moshi', name: 'moshi', version: '1.15.0'
+    implementation group: 'com.squareup.moshi', name: 'moshi', version: '1.15.1'
     // nanojson
     implementation group: 'com.grack', name: 'nanojson', version: '1.8'
     // org.json

--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ repositories {
 }
 
 ext {
-    avajeJsonVersion = '1.9'
+    avajeJsonVersion = '1.11'
     jacksonVersion = '2.17.1'
     dslJsonVersion = '1.10.0'
     johnzonVersion = '1.2.21'

--- a/build.gradle
+++ b/build.gradle
@@ -68,7 +68,7 @@ dependencies {
     implementation group: 'jakarta.json', name: 'jakarta.json-api', version: '2.1.3'
     implementation group: 'org.glassfish', name: 'jakarta.json', version: '2.0.1'
     // json-io
-    implementation group: 'com.cedarsoftware', name: 'json-io', version: '4.14.0'
+    implementation group: 'com.cedarsoftware', name: 'json-io', version: '4.24.0'
     // json-simple
     implementation group: 'com.googlecode.json-simple', name: 'json-simple', version: '1.1.1'
     // json-smart

--- a/build.gradle
+++ b/build.gradle
@@ -83,7 +83,7 @@ dependencies {
     // moshi
     implementation group: 'com.squareup.moshi', name: 'moshi', version: '1.15.1'
     // nanojson
-    implementation group: 'com.grack', name: 'nanojson', version: '1.8'
+    implementation group: 'com.grack', name: 'nanojson', version: '1.9'
     // org.json
     implementation group: 'org.json', name: 'json', version: '20231013'
     // purejson

--- a/build.gradle
+++ b/build.gradle
@@ -72,7 +72,7 @@ dependencies {
     // json-simple
     implementation group: 'com.googlecode.json-simple', name: 'json-simple', version: '1.1.1'
     // json-smart
-    implementation group: 'net.minidev', name: 'json-smart', version: '2.4.11'
+    implementation group: 'net.minidev', name: 'json-smart', version: '2.5.1'
     // LoganSquare
     implementation group: 'com.bluelinelabs', name: 'logansquare', version: '1.3.7'
     annotationProcessor group: 'com.bluelinelabs', name: 'logansquare-compiler', version: '1.3.7'

--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ repositories {
 ext {
     avajeJsonVersion = '1.11'
     jacksonVersion = '2.17.1'
-    dslJsonVersion = '1.10.0'
+    dslJsonVersion = '2.0.2'
     johnzonVersion = '1.2.21'
     jmhVersion = '1.35'
 }
@@ -42,8 +42,8 @@ dependencies {
     // boon
     implementation group: 'io.fastjson', name: 'boon', version: '0.34'
     // DSL-json
-    implementation group: 'com.dslplatform', name: 'dsl-json-java8', version: "${dslJsonVersion}"
-    annotationProcessor group: 'com.dslplatform', name: 'dsl-json-java8', version: "${dslJsonVersion}"
+    implementation group: 'com.dslplatform', name: 'dsl-json', version: "${dslJsonVersion}"
+    annotationProcessor group: 'com.dslplatform', name: 'dsl-json', version: "${dslJsonVersion}"
     // FastJson
     implementation group: 'com.alibaba.fastjson2', name: 'fastjson2', version: '2.0.48'
     implementation group: 'com.alibaba.fastjson2', name: 'fastjson2-incubator-vector', version: '2.0.48'

--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ repositories {
 
 ext {
     avajeJsonVersion = '1.9'
-    jacksonVersion = '2.16.0'
+    jacksonVersion = '2.17.1'
     dslJsonVersion = '1.10.0'
     johnzonVersion = '1.2.21'
     jmhVersion = '1.35'

--- a/build.gradle
+++ b/build.gradle
@@ -52,7 +52,7 @@ dependencies {
     // GENSON
     implementation group: 'com.owlike', name: 'genson', version: '1.6'
     // GSON
-    implementation group: 'com.google.code.gson', name: 'gson', version: '2.10.1'
+    implementation group: 'com.google.code.gson', name: 'gson', version: '2.11.0'
     // Jackson
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: "${jacksonVersion}"
     implementation group: 'com.fasterxml.jackson.module', name: 'jackson-module-afterburner', version: "${jacksonVersion}"

--- a/build.gradle
+++ b/build.gradle
@@ -93,7 +93,7 @@ dependencies {
     // tapestry
     implementation group: 'org.apache.tapestry', name: 'tapestry-json', version: '5.8.6'
     // underscore-java
-    implementation group: 'com.github.javadev', name: 'underscore', version: '1.97'
+    implementation group: 'com.github.javadev', name: 'underscore', version: '1.101'
     // yasson
     implementation group: 'org.eclipse', name: 'yasson', version: '3.0.3'
     // QuickBuffers

--- a/build.gradle
+++ b/build.gradle
@@ -64,7 +64,7 @@ dependencies {
     implementation group: 'org.apache.johnzon', name: 'johnzon-core', classifier: 'jakarta', version: "${johnzonVersion}"
     implementation group: 'org.apache.johnzon', name: 'johnzon-mapper', classifier: 'jakarta', version: "${johnzonVersion}"
     // Jakarta
-    implementation group: 'jakarta.json.bind', name: 'jakarta.json.bind-api', version: '3.0.0'
+    implementation group: 'jakarta.json.bind', name: 'jakarta.json.bind-api', version: '3.0.1'
     implementation group: 'jakarta.json', name: 'jakarta.json-api', version: '2.1.3'
     implementation group: 'org.glassfish', name: 'jakarta.json', version: '2.0.1'
     // json-io

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ ext {
     avajeJsonVersion = '1.11'
     jacksonVersion = '2.17.1'
     dslJsonVersion = '2.0.2'
-    johnzonVersion = '1.2.21'
+    johnzonVersion = '2.0.1'
     jmhVersion = '1.35'
 }
 
@@ -61,8 +61,8 @@ dependencies {
     // jodd
     implementation group: 'org.jodd', name: 'jodd-json', version: '6.0.3'
     // johnzon
-    implementation group: 'org.apache.johnzon', name: 'johnzon-core', classifier: 'jakarta', version: "${johnzonVersion}"
-    implementation group: 'org.apache.johnzon', name: 'johnzon-mapper', classifier: 'jakarta', version: "${johnzonVersion}"
+    implementation group: 'org.apache.johnzon', name: 'johnzon-core', version: "${johnzonVersion}"
+    implementation group: 'org.apache.johnzon', name: 'johnzon-mapper', version: "${johnzonVersion}"
     // Jakarta
     implementation group: 'jakarta.json.bind', name: 'jakarta.json.bind-api', version: '3.0.1'
     implementation group: 'jakarta.json', name: 'jakarta.json-api', version: '2.1.3'

--- a/build.gradle
+++ b/build.gradle
@@ -85,7 +85,7 @@ dependencies {
     // nanojson
     implementation group: 'com.grack', name: 'nanojson', version: '1.9'
     // org.json
-    implementation group: 'org.json', name: 'json', version: '20231013'
+    implementation group: 'org.json', name: 'json', version: '20240303'
     // purejson
     implementation group: 'io.github.senthilganeshs', name: 'purejson', version: '1.0.1'
     // qson

--- a/src/main/java/com/github/fabienrenaud/jjb/provider/ClientsJsonProvider.java
+++ b/src/main/java/com/github/fabienrenaud/jjb/provider/ClientsJsonProvider.java
@@ -1,7 +1,5 @@
 package com.github.fabienrenaud.jjb.provider;
 
-import com.cedarsoftware.util.io.JsonReader;
-import com.cedarsoftware.util.io.JsonWriter;
 import com.dslplatform.json.DslJson;
 import com.dslplatform.json.runtime.Settings;
 import com.fasterxml.jackson.core.JsonFactory;
@@ -46,8 +44,6 @@ import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.UUID;
 
 public class ClientsJsonProvider implements JsonProvider<Clients> {
@@ -164,12 +160,7 @@ public class ClientsJsonProvider implements JsonProvider<Clients> {
             .builder()
             .adapter(new JsonStream(/* serializeNulls */ true, /* serializeEmpty */ true, /* failOnUnknown */ false)).build().type(Clients.class);
 
-    private final Map<String, Object> jsonioStreamOptions = new HashMap<>();
-
     public ClientsJsonProvider() {
-
-        jsonioStreamOptions.put(JsonReader.USE_MAPS, true);
-        jsonioStreamOptions.put(JsonWriter.TYPE, false);
 
         // set johnzon JsonReader (default is `JsonProvider.provider()`)
         jakarta.json.spi.JsonProvider johnzonProvider = new JsonProviderImpl();
@@ -241,11 +232,6 @@ public class ClientsJsonProvider implements JsonProvider<Clients> {
     @Override
     public Mapper johnzon() {
         return johnzon;
-    }
-
-    @Override
-    public Map<String, Object> jsonioStreamOptions() {
-        return jsonioStreamOptions;
     }
 
     @Override

--- a/src/main/java/com/github/fabienrenaud/jjb/provider/ClientsJsonProvider.java
+++ b/src/main/java/com/github/fabienrenaud/jjb/provider/ClientsJsonProvider.java
@@ -171,7 +171,7 @@ public class ClientsJsonProvider implements JsonProvider<Clients> {
         jsonioStreamOptions.put(JsonReader.USE_MAPS, true);
         jsonioStreamOptions.put(JsonWriter.TYPE, false);
 
-        // set johnson JsonReader (default is `JsonProvider.provider()`)
+        // set johnzon JsonReader (default is `JsonProvider.provider()`)
         jakarta.json.spi.JsonProvider johnzonProvider = new JsonProviderImpl();
         johnzon = new org.apache.johnzon.mapper.MapperBuilder()
             .setReaderFactory(johnzonProvider.createReaderFactory(Collections.emptyMap()))

--- a/src/main/java/com/github/fabienrenaud/jjb/provider/ClientsJsonProvider.java
+++ b/src/main/java/com/github/fabienrenaud/jjb/provider/ClientsJsonProvider.java
@@ -158,10 +158,10 @@ public class ClientsJsonProvider implements JsonProvider<Clients> {
     private final DslJson<Object> dsljson_reflection = new DslJson<>(Settings.withRuntime());//don't include generated classes
 
     private final io.avaje.jsonb.JsonType<Clients> avajeJsonb_jackson = io.avaje.jsonb.Jsonb
-            .newBuilder()
+            .builder()
             .adapter(new JacksonAdapter(/* serializeNulls */ true, /* serializeEmpty */ true, /* failOnUnknown */ false)).build().type(Clients.class);
     private final io.avaje.jsonb.JsonType<Clients> avajeJsonb_default = io.avaje.jsonb.Jsonb
-            .newBuilder()
+            .builder()
             .adapter(new JsonStream(/* serializeNulls */ true, /* serializeEmpty */ true, /* failOnUnknown */ false)).build().type(Clients.class);
 
     private final Map<String, Object> jsonioStreamOptions = new HashMap<>();

--- a/src/main/java/com/github/fabienrenaud/jjb/provider/JsonProvider.java
+++ b/src/main/java/com/github/fabienrenaud/jjb/provider/JsonProvider.java
@@ -14,8 +14,6 @@ import jakarta.json.bind.Jsonb;
 import us.hebi.quickbuf.JsonSink;
 import us.hebi.quickbuf.ProtoMessage;
 
-import java.util.Map;
-
 public interface JsonProvider<T> {
 
     Gson gson();
@@ -41,8 +39,6 @@ public interface JsonProvider<T> {
     org.boon.json.ObjectMapper boon();
 
     Mapper johnzon();
-
-    Map<String, Object> jsonioStreamOptions();
 
     DslJson<Object> dsljson();
 

--- a/src/main/java/com/github/fabienrenaud/jjb/provider/UsersJsonProvider.java
+++ b/src/main/java/com/github/fabienrenaud/jjb/provider/UsersJsonProvider.java
@@ -66,7 +66,7 @@ public class UsersJsonProvider implements JsonProvider<Users> {
         jsonioStreamOptions.put(JsonReader.USE_MAPS, true);
         jsonioStreamOptions.put(JsonWriter.TYPE, false);
 
-        // set johnson JsonReader (default is `JsonProvider.provider()`)
+        // set johnzon JsonReader (default is `JsonProvider.provider()`)
         jakarta.json.spi.JsonProvider johnzonProvider = new JsonProviderImpl();
         johnzon = new org.apache.johnzon.mapper.MapperBuilder()
             .setReaderFactory(johnzonProvider.createReaderFactory(Collections.emptyMap()))

--- a/src/main/java/com/github/fabienrenaud/jjb/provider/UsersJsonProvider.java
+++ b/src/main/java/com/github/fabienrenaud/jjb/provider/UsersJsonProvider.java
@@ -59,8 +59,8 @@ public class UsersJsonProvider implements JsonProvider<Users> {
 
     private final Map<String, Object> jsonioStreamOptions = new HashMap<>();
 
-    private final JsonType<Users> avajeJsonb_jackson = io.avaje.jsonb.Jsonb.newBuilder().adapter(new JacksonAdapter(/* serializeNulls */ true, /* serializeEmpty */ true, /* failOnUnknown */ false)).build().type(Users.class);
-    private final JsonType<Users> avajeJsonb_default = io.avaje.jsonb.Jsonb.newBuilder().adapter(new JsonStream(/* serializeNulls */ true, /* serializeEmpty */ true, /* failOnUnknown */ false)).build().type(Users.class);
+    private final JsonType<Users> avajeJsonb_jackson = io.avaje.jsonb.Jsonb.builder().adapter(new JacksonAdapter(/* serializeNulls */ true, /* serializeEmpty */ true, /* failOnUnknown */ false)).build().type(Users.class);
+    private final JsonType<Users> avajeJsonb_default = io.avaje.jsonb.Jsonb.builder().adapter(new JsonStream(/* serializeNulls */ true, /* serializeEmpty */ true, /* failOnUnknown */ false)).build().type(Users.class);
 
     public UsersJsonProvider() {
         jsonioStreamOptions.put(JsonReader.USE_MAPS, true);

--- a/src/main/java/com/github/fabienrenaud/jjb/provider/UsersJsonProvider.java
+++ b/src/main/java/com/github/fabienrenaud/jjb/provider/UsersJsonProvider.java
@@ -1,7 +1,5 @@
 package com.github.fabienrenaud.jjb.provider;
 
-import com.cedarsoftware.util.io.JsonReader;
-import com.cedarsoftware.util.io.JsonWriter;
 import com.dslplatform.json.DslJson;
 import com.dslplatform.json.runtime.Settings;
 import com.fasterxml.jackson.core.JsonFactory;
@@ -24,8 +22,6 @@ import org.apache.johnzon.mapper.Mapper;
 import org.eclipse.yasson.JsonBindingProvider;
 
 import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
 
 import jakarta.json.bind.Jsonb;
 import us.hebi.quickbuf.JsonSink;
@@ -57,14 +53,10 @@ public class UsersJsonProvider implements JsonProvider<Users> {
     private final DslJson<Object> dsljson = new DslJson<>(Settings.withRuntime().includeServiceLoader());
     private final DslJson<Object> dsljson_reflection = new DslJson<>(Settings.withRuntime());//don't include generated classes
 
-    private final Map<String, Object> jsonioStreamOptions = new HashMap<>();
-
     private final JsonType<Users> avajeJsonb_jackson = io.avaje.jsonb.Jsonb.builder().adapter(new JacksonAdapter(/* serializeNulls */ true, /* serializeEmpty */ true, /* failOnUnknown */ false)).build().type(Users.class);
     private final JsonType<Users> avajeJsonb_default = io.avaje.jsonb.Jsonb.builder().adapter(new JsonStream(/* serializeNulls */ true, /* serializeEmpty */ true, /* failOnUnknown */ false)).build().type(Users.class);
 
     public UsersJsonProvider() {
-        jsonioStreamOptions.put(JsonReader.USE_MAPS, true);
-        jsonioStreamOptions.put(JsonWriter.TYPE, false);
 
         // set johnzon JsonReader (default is `JsonProvider.provider()`)
         jakarta.json.spi.JsonProvider johnzonProvider = new JsonProviderImpl();
@@ -130,11 +122,6 @@ public class UsersJsonProvider implements JsonProvider<Users> {
     @Override
     public Mapper johnzon() {
         return johnzon;
-    }
-
-    @Override
-    public Map<String, Object> jsonioStreamOptions() {
-        return jsonioStreamOptions;
     }
 
     @Override

--- a/src/main/java/com/github/fabienrenaud/jjb/stream/Deserialization.java
+++ b/src/main/java/com/github/fabienrenaud/jjb/stream/Deserialization.java
@@ -12,6 +12,8 @@ import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
+import com.cedarsoftware.io.JsonIo;
+import com.cedarsoftware.io.ReadOptionsBuilder;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -90,8 +92,14 @@ public class Deserialization extends JsonBench {
 
     @Benchmark
     @Override
-    public Object jsonio() throws Exception {
-        return com.cedarsoftware.util.io.JsonReader.jsonToJava(JSON_SOURCE().nextInputStream(), JSON_SOURCE().provider().jsonioStreamOptions());
+    public Object jsonio() {
+        
+        // returnAsNativeJsonObjects maps to old JsonWriter.USE_MAPS=true behavior, 
+        // see {@link JsonIo#getReadOptionsBuilder(java.util.Map)} and 
+        // <a href="https://github.com/jdereg/json-io/blob/4.19.1/changelog.md">the v4.19 changelog</a>
+        return JsonIo.toObjects(
+            JSON_SOURCE().nextInputStream(), new ReadOptionsBuilder().returnAsNativeJsonObjects().build(), null
+        );
     }
 
     @Benchmark

--- a/src/main/java/com/github/fabienrenaud/jjb/stream/Serialization.java
+++ b/src/main/java/com/github/fabienrenaud/jjb/stream/Serialization.java
@@ -4,6 +4,8 @@ import java.io.ByteArrayOutputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
 
+import com.cedarsoftware.io.JsonIo;
+import com.cedarsoftware.io.WriteOptionsBuilder;
 import org.openjdk.jmh.annotations.Benchmark;
 
 import com.fasterxml.jackson.core.JsonGenerator;
@@ -93,8 +95,10 @@ public class Serialization extends JsonBench {
 
     @Benchmark
     @Override
-    public Object jsonio() throws Exception {
-        return com.cedarsoftware.util.io.JsonWriter.objectToJson(JSON_SOURCE().nextPojo(), JSON_SOURCE().provider().jsonioStreamOptions());
+    public Object jsonio() {
+
+        // showTypeInfoNever maps to old TYPE=false behavior see {@link JsonIo#getWriteOptionsBuilder(java.util.Map)}
+        return JsonIo.toJson(JSON_SOURCE().nextPojo(), new WriteOptionsBuilder().showTypeInfoNever().build());
     }
 
     @Benchmark

--- a/src/test/java/com/github/fabienrenaud/jjb/JsonBenchmark.java
+++ b/src/test/java/com/github/fabienrenaud/jjb/JsonBenchmark.java
@@ -1,5 +1,6 @@
 package com.github.fabienrenaud.jjb;
 
+import com.cedarsoftware.io.WriteOptionsBuilder;
 import com.github.fabienrenaud.jjb.model.Clients;
 import com.github.fabienrenaud.jjb.model.Users;
 import com.github.fabienrenaud.jjb.support.Api;
@@ -34,8 +35,8 @@ public abstract class JsonBenchmark<T> {
 
         if (o instanceof Users || o instanceof Clients) {
             testPojo((T) o);
-        } else if (o instanceof com.cedarsoftware.util.io.JsonObject) {
-            String v = com.cedarsoftware.util.io.JsonWriter.objectToJson(o, BENCH.JSON_SOURCE().provider().jsonioStreamOptions());
+        } else if (o instanceof com.cedarsoftware.io.JsonObject) {
+            String v = com.cedarsoftware.io.JsonIo.toJson(o, new WriteOptionsBuilder().showTypeInfoNever().build());
             testString(v);
         } else if (o instanceof com.grack.nanojson.JsonObject) {
             String v = com.grack.nanojson.JsonWriter.string(o);


### PR DESCRIPTION
I just wanted to update the Jackson lib, but then i ended up checking the whole list ;)

After some fighting with (non-semver) breaking changes in avaje-jsonb and json-io i was able to execute both `./run ser` and `.run/deser` successfully.

Some notable points:
* [ ] dsl-json had a new major release (v2.x). I followed the [migration section in the project readme](https://github.com/ngs-doo/dsl-json?tab=readme-ov-file#upgrade-from-v1), looking at this no further modifications are necessary, but you never know... so i added this commit at the very end in case we want to drop it again
* [ ] same with apache johnzon. there does not seem to be much information available on any migration process… so just putting this here, to be dropped easily again in case execution fails with it
* [ ] json-io had a typo in the version no. in the README.md which was introduced via a manual revert [here](https://github.com/fabienrenaud/java-json-benchmark/pull/92/commits/2f5d74d9d93431e5f8045269d743e2632e04c623). Probably it was reverted b/c i found out the hard way there was a breaking change in the API and the migration instructions are barely existent. However, works now with the new API  – if not, simply `git revert 91d279b` before merging (i may also simply rebase and drop the commit if desired)
* [ ] I had a little confusion about senthilganeshs/jsonp vs. https://github.com/tonivade/purejson. The former hasn't seen any activity in the last five years, while the latter seems pretty active, but is not yet included in the shootout – maybe a good one to add?