### PR TITLE
Update json-io version from 4.24.0 to 4.94.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ The results here-below were computed on January the 30th, 2024 with the followin
 | jodd json    | 6.0.3    |
 | johnzon      | 1.2.21   |
 | jakarta      | 2.1.3    |
-| json-io      | 4.24.0   |
+| json-io      | 4.94.0   |
 | simplejson   | 1.1.1    |
 | json-smart   | 2.4.11   |
 | logansquare  | 1.3.7    |


### PR DESCRIPTION
## Summary

Update the json-io library version reference in the README.md version table from `4.24.0` to `4.94.0` to reflect the current release.

- Updated json-io version in the library versions table from `4.24.0` → `4.94.0`