### PR TITLE
Upgrade Java runtime 17 to 25

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -20,11 +20,11 @@ jobs:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0
-    - name: Set up JDK 17
+    - name: Set up JDK 25
       uses: actions/setup-java@v3
       with:
         distribution: 'temurin'
-        java-version: '17'
+        java-version: '25'
         cache: 'gradle'
     - name: Build with Gradle
       run: chmod +x gradlew && ./gradlew assemble

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM amazoncorretto:17-al2-jdk
+FROM amazoncorretto:25-al2023-jdk@sha256:3371b8e140b9d38a267c8ee129d154049a78cd8af79fc68b7538d468466fcdd5
 
 # Create a user
 RUN yum update -y && \

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Not evaluated are: RAM utilization, compression, payloads > 1 MB.
 
 ## Results
 
-The benchmarks are written with [JMH](http://openjdk.java.net/projects/code-tools/jmh/) and for Java 17.
+The benchmarks are written with [JMH](http://openjdk.java.net/projects/code-tools/jmh/) and for Java 25.
 
 The results here-below were computed on February the 28th, 2026 with the following libraries and versions:
 
@@ -138,7 +138,7 @@ JMH info:
 
 Prerequisites:
 
-* JDK 17; and JAVA_HOME set.
+* JDK 25; and JAVA_HOME set.
 * make
 
 By default, running `./run ser` (`./run deser` respectively) will run
@@ -177,7 +177,7 @@ Build and run:
 
 Prerequisites:
 
-* JDK 17; and JAVA_HOME set.
+* JDK 25; and JAVA_HOME set.
 * make
 * [packer](https://www.packer.io/)
 * [awscli](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html) and configured

--- a/build.gradle
+++ b/build.gradle
@@ -14,8 +14,8 @@ application {
 
 java {
     toolchain {
-        sourceCompatibility = 17
-        targetCompatibility = 17
+        sourceCompatibility = 25
+        targetCompatibility = 25
     }
 }
 


### PR DESCRIPTION
## Motivation

This PR upgrades Java runtime 17 to 25.

According to packer `ami.json` (6023efb6), Run 2026-02-28 was executed with `java-25-amazon-corretto` and `al2023`. We should update other files.

## File changes

- `Dockerfile` base image: Java 17 on AL2 -> Java 25 on AL2023
- `build.gradle`: sourceCompatibility / targetCompatibility
- `README.md`
