### PR TITLE
Add DATABIND coverage for json-io 4.102.0; cache provider options; switch to non-deprecated toMaps()

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,7 @@ java {
 }
 
 repositories {
+    mavenLocal()
     mavenCentral()
 }
 
@@ -74,7 +75,7 @@ dependencies {
     implementation 'jakarta.json:jakarta.json-api:2.1.3'
     implementation 'org.glassfish:jakarta.json:2.0.1'
     // json-io
-    implementation 'com.cedarsoftware:json-io:4.101.0'
+    implementation 'com.cedarsoftware:json-io:4.102.0'
     // json-simple
     implementation 'com.googlecode.json-simple:json-simple:1.1.1'
     // json-smart

--- a/build.gradle
+++ b/build.gradle
@@ -74,7 +74,7 @@ dependencies {
     implementation 'jakarta.json:jakarta.json-api:2.1.3'
     implementation 'org.glassfish:jakarta.json:2.0.1'
     // json-io
-    implementation 'com.cedarsoftware:json-io:4.88.0'
+    implementation 'com.cedarsoftware:json-io:4.101.0'
     // json-simple
     implementation 'com.googlecode.json-simple:json-simple:1.1.1'
     // json-smart

--- a/src/main/java/com/github/fabienrenaud/jjb/databind/Deserialization.java
+++ b/src/main/java/com/github/fabienrenaud/jjb/databind/Deserialization.java
@@ -2,6 +2,7 @@ package com.github.fabienrenaud.jjb.databind;
 
 import com.alibaba.fastjson2.JSON;
 import com.bluelinelabs.logansquare.LoganSquare;
+import com.cedarsoftware.io.JsonIo;
 import com.github.fabienrenaud.jjb.JsonBench;
 import com.github.fabienrenaud.jjb.data.JsonSource;
 import com.google.gson.JsonSyntaxException;
@@ -160,5 +161,12 @@ public class Deserialization extends JsonBench {
     @Override
     public Object djomo() throws Exception {
         return JSON_SOURCE().provider().djomo().fromString(JSON_SOURCE().nextString(), JSON_SOURCE().pojoType());
+    }
+
+    @Benchmark
+    @Override
+    public Object jsonio() {
+        // Default ReadOptions; json-io infers field types from the target Class.
+        return JsonIo.toJava(JSON_SOURCE().nextString(), null).asClass(JSON_SOURCE().pojoType());
     }
 }

--- a/src/main/java/com/github/fabienrenaud/jjb/databind/Serialization.java
+++ b/src/main/java/com/github/fabienrenaud/jjb/databind/Serialization.java
@@ -3,7 +3,6 @@ package com.github.fabienrenaud.jjb.databind;
 import com.alibaba.fastjson2.JSON;
 import com.bluelinelabs.logansquare.LoganSquare;
 import com.cedarsoftware.io.JsonIo;
-import com.cedarsoftware.io.WriteOptionsBuilder;
 import com.github.fabienrenaud.jjb.JsonBench;
 import com.github.fabienrenaud.jjb.JsonUtils;
 import com.github.fabienrenaud.jjb.data.JsonSource;
@@ -206,8 +205,7 @@ public class Serialization extends JsonBench {
     public Object jsonio() {
         // standardJson() produces Jackson-compatible JSON: suppresses @type, @id/@ref,
         // root type info; stringifies non-String map keys; emits ISO-8601 dates.
-        // Suitable for the round-trip check (Jackson parses our output) and for
-        // apples-to-apples comparison with other databind libraries.
-        return JsonIo.toJson(JSON_SOURCE().nextPojo(), new WriteOptionsBuilder().standardJson().build());
+        // Cached on the provider to match how Jackson/Gson/etc. cache their mappers.
+        return JsonIo.toJson(JSON_SOURCE().nextPojo(), JSON_SOURCE().provider().jsonioWriteOptions());
     }
 }

--- a/src/main/java/com/github/fabienrenaud/jjb/databind/Serialization.java
+++ b/src/main/java/com/github/fabienrenaud/jjb/databind/Serialization.java
@@ -2,6 +2,8 @@ package com.github.fabienrenaud.jjb.databind;
 
 import com.alibaba.fastjson2.JSON;
 import com.bluelinelabs.logansquare.LoganSquare;
+import com.cedarsoftware.io.JsonIo;
+import com.cedarsoftware.io.WriteOptionsBuilder;
 import com.github.fabienrenaud.jjb.JsonBench;
 import com.github.fabienrenaud.jjb.JsonUtils;
 import com.github.fabienrenaud.jjb.data.JsonSource;
@@ -197,5 +199,13 @@ public class Serialization extends JsonBench {
         ByteArrayOutputStream baos = JsonUtils.byteArrayOutputStream();
         JSON_SOURCE().provider().djomo().write(JSON_SOURCE().nextPojo(), baos);
         return baos;
+    }
+
+    @Benchmark
+    @Override
+    public Object jsonio() {
+        // showTypeInfoNever produces standard JSON without json-io's @type metadata,
+        // so the test harness's Jackson-based round-trip check parses it cleanly.
+        return JsonIo.toJson(JSON_SOURCE().nextPojo(), new WriteOptionsBuilder().showTypeInfoNever().build());
     }
 }

--- a/src/main/java/com/github/fabienrenaud/jjb/databind/Serialization.java
+++ b/src/main/java/com/github/fabienrenaud/jjb/databind/Serialization.java
@@ -204,8 +204,10 @@ public class Serialization extends JsonBench {
     @Benchmark
     @Override
     public Object jsonio() {
-        // showTypeInfoNever produces standard JSON without json-io's @type metadata,
-        // so the test harness's Jackson-based round-trip check parses it cleanly.
-        return JsonIo.toJson(JSON_SOURCE().nextPojo(), new WriteOptionsBuilder().showTypeInfoNever().build());
+        // standardJson() produces Jackson-compatible JSON: suppresses @type, @id/@ref,
+        // root type info; stringifies non-String map keys; emits ISO-8601 dates.
+        // Suitable for the round-trip check (Jackson parses our output) and for
+        // apples-to-apples comparison with other databind libraries.
+        return JsonIo.toJson(JSON_SOURCE().nextPojo(), new WriteOptionsBuilder().standardJson().build());
     }
 }

--- a/src/main/java/com/github/fabienrenaud/jjb/provider/ClientsJsonProvider.java
+++ b/src/main/java/com/github/fabienrenaud/jjb/provider/ClientsJsonProvider.java
@@ -1,5 +1,9 @@
 package com.github.fabienrenaud.jjb.provider;
 
+import com.cedarsoftware.io.ReadOptions;
+import com.cedarsoftware.io.ReadOptionsBuilder;
+import com.cedarsoftware.io.WriteOptions;
+import com.cedarsoftware.io.WriteOptionsBuilder;
 import com.dslplatform.json.DslJson;
 import com.dslplatform.json.runtime.Settings;
 import com.fasterxml.jackson.core.JsonFactory;
@@ -162,6 +166,11 @@ public class ClientsJsonProvider implements JsonProvider<Clients> {
 
     private final com.bigcloud.djomo.Json djomo = new com.bigcloud.djomo.Json();
 
+    // json-io options are immutable+thread-safe once built; cache one instance per provider
+    // to match how every other library here caches its mapper/parser/serializer.
+    private final WriteOptions jsonioWriteOptions = new WriteOptionsBuilder().standardJson().build();
+    private final ReadOptions jsonioReadOptionsMaps = new ReadOptionsBuilder().returnAsNativeJsonObjects().build();
+
     public ClientsJsonProvider() {
 
         // set johnzon JsonReader (default is `JsonProvider.provider()`)
@@ -289,6 +298,16 @@ public class ClientsJsonProvider implements JsonProvider<Clients> {
     @Override
     public com.bigcloud.djomo.Json djomo() {
         return djomo;
+    }
+
+    @Override
+    public WriteOptions jsonioWriteOptions() {
+        return jsonioWriteOptions;
+    }
+
+    @Override
+    public ReadOptions jsonioReadOptionsMaps() {
+        return jsonioReadOptionsMaps;
     }
 
     private static final ThreadLocal<QuickbufSchema.Clients> QUICKBUF_MESSAGE = ThreadLocal.withInitial(QuickbufSchema.Clients::newInstance);

--- a/src/main/java/com/github/fabienrenaud/jjb/provider/ClientsJsonProvider.java
+++ b/src/main/java/com/github/fabienrenaud/jjb/provider/ClientsJsonProvider.java
@@ -1,7 +1,5 @@
 package com.github.fabienrenaud.jjb.provider;
 
-import com.cedarsoftware.io.ReadOptions;
-import com.cedarsoftware.io.ReadOptionsBuilder;
 import com.cedarsoftware.io.WriteOptions;
 import com.cedarsoftware.io.WriteOptionsBuilder;
 import com.dslplatform.json.DslJson;
@@ -166,10 +164,10 @@ public class ClientsJsonProvider implements JsonProvider<Clients> {
 
     private final com.bigcloud.djomo.Json djomo = new com.bigcloud.djomo.Json();
 
-    // json-io options are immutable+thread-safe once built; cache one instance per provider
-    // to match how every other library here caches its mapper/parser/serializer.
+    // json-io WriteOptions is immutable+thread-safe once built; cache one instance per provider
+    // to match how every other library here caches its mapper/parser/serializer. Read-side uses
+    // JsonIo.toMaps()/toJava() which manage their own option caches internally.
     private final WriteOptions jsonioWriteOptions = new WriteOptionsBuilder().standardJson().build();
-    private final ReadOptions jsonioReadOptionsMaps = new ReadOptionsBuilder().returnAsNativeJsonObjects().build();
 
     public ClientsJsonProvider() {
 
@@ -303,11 +301,6 @@ public class ClientsJsonProvider implements JsonProvider<Clients> {
     @Override
     public WriteOptions jsonioWriteOptions() {
         return jsonioWriteOptions;
-    }
-
-    @Override
-    public ReadOptions jsonioReadOptionsMaps() {
-        return jsonioReadOptionsMaps;
     }
 
     private static final ThreadLocal<QuickbufSchema.Clients> QUICKBUF_MESSAGE = ThreadLocal.withInitial(QuickbufSchema.Clients::newInstance);

--- a/src/main/java/com/github/fabienrenaud/jjb/provider/JsonProvider.java
+++ b/src/main/java/com/github/fabienrenaud/jjb/provider/JsonProvider.java
@@ -1,5 +1,7 @@
 package com.github.fabienrenaud.jjb.provider;
 
+import com.cedarsoftware.io.ReadOptions;
+import com.cedarsoftware.io.WriteOptions;
 import com.dslplatform.json.DslJson;
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -61,5 +63,9 @@ public interface JsonProvider<T> {
     JsonSink quickbufSink();
 
     com.bigcloud.djomo.Json djomo();
+
+    WriteOptions jsonioWriteOptions();
+
+    ReadOptions jsonioReadOptionsMaps();
 
 }

--- a/src/main/java/com/github/fabienrenaud/jjb/provider/JsonProvider.java
+++ b/src/main/java/com/github/fabienrenaud/jjb/provider/JsonProvider.java
@@ -1,6 +1,5 @@
 package com.github.fabienrenaud.jjb.provider;
 
-import com.cedarsoftware.io.ReadOptions;
 import com.cedarsoftware.io.WriteOptions;
 import com.dslplatform.json.DslJson;
 import com.fasterxml.jackson.core.JsonFactory;
@@ -65,7 +64,5 @@ public interface JsonProvider<T> {
     com.bigcloud.djomo.Json djomo();
 
     WriteOptions jsonioWriteOptions();
-
-    ReadOptions jsonioReadOptionsMaps();
 
 }

--- a/src/main/java/com/github/fabienrenaud/jjb/provider/UsersJsonProvider.java
+++ b/src/main/java/com/github/fabienrenaud/jjb/provider/UsersJsonProvider.java
@@ -1,7 +1,5 @@
 package com.github.fabienrenaud.jjb.provider;
 
-import com.cedarsoftware.io.ReadOptions;
-import com.cedarsoftware.io.ReadOptionsBuilder;
 import com.cedarsoftware.io.WriteOptions;
 import com.cedarsoftware.io.WriteOptionsBuilder;
 import com.dslplatform.json.DslJson;
@@ -62,10 +60,10 @@ public class UsersJsonProvider implements JsonProvider<Users> {
 
     private final com.bigcloud.djomo.Json djomo = new com.bigcloud.djomo.Json();
 
-    // json-io options are immutable+thread-safe once built; cache one instance per provider
-    // to match how every other library here caches its mapper/parser/serializer.
+    // json-io WriteOptions is immutable+thread-safe once built; cache one instance per provider
+    // to match how every other library here caches its mapper/parser/serializer. Read-side uses
+    // JsonIo.toMaps()/toJava() which manage their own option caches internally.
     private final WriteOptions jsonioWriteOptions = new WriteOptionsBuilder().standardJson().build();
-    private final ReadOptions jsonioReadOptionsMaps = new ReadOptionsBuilder().returnAsNativeJsonObjects().build();
 
     public UsersJsonProvider() {
 
@@ -199,11 +197,6 @@ public class UsersJsonProvider implements JsonProvider<Users> {
     @Override
     public WriteOptions jsonioWriteOptions() {
         return jsonioWriteOptions;
-    }
-
-    @Override
-    public ReadOptions jsonioReadOptionsMaps() {
-        return jsonioReadOptionsMaps;
     }
 
     private static final ThreadLocal<QuickbufSchema.Users> QUICKBUF_MESSAGE = ThreadLocal.withInitial(QuickbufSchema.Users::newInstance);

--- a/src/main/java/com/github/fabienrenaud/jjb/provider/UsersJsonProvider.java
+++ b/src/main/java/com/github/fabienrenaud/jjb/provider/UsersJsonProvider.java
@@ -1,5 +1,9 @@
 package com.github.fabienrenaud.jjb.provider;
 
+import com.cedarsoftware.io.ReadOptions;
+import com.cedarsoftware.io.ReadOptionsBuilder;
+import com.cedarsoftware.io.WriteOptions;
+import com.cedarsoftware.io.WriteOptionsBuilder;
 import com.dslplatform.json.DslJson;
 import com.dslplatform.json.runtime.Settings;
 import com.fasterxml.jackson.core.JsonFactory;
@@ -57,6 +61,11 @@ public class UsersJsonProvider implements JsonProvider<Users> {
     private final JsonType<Users> avajeJsonb_default = io.avaje.jsonb.Jsonb.builder().adapter(new JsonStream(/* serializeNulls */ true, /* serializeEmpty */ true, /* failOnUnknown */ false)).build().type(Users.class);
 
     private final com.bigcloud.djomo.Json djomo = new com.bigcloud.djomo.Json();
+
+    // json-io options are immutable+thread-safe once built; cache one instance per provider
+    // to match how every other library here caches its mapper/parser/serializer.
+    private final WriteOptions jsonioWriteOptions = new WriteOptionsBuilder().standardJson().build();
+    private final ReadOptions jsonioReadOptionsMaps = new ReadOptionsBuilder().returnAsNativeJsonObjects().build();
 
     public UsersJsonProvider() {
 
@@ -185,6 +194,16 @@ public class UsersJsonProvider implements JsonProvider<Users> {
     @Override
     public com.bigcloud.djomo.Json djomo() {
         return djomo;
+    }
+
+    @Override
+    public WriteOptions jsonioWriteOptions() {
+        return jsonioWriteOptions;
+    }
+
+    @Override
+    public ReadOptions jsonioReadOptionsMaps() {
+        return jsonioReadOptionsMaps;
     }
 
     private static final ThreadLocal<QuickbufSchema.Users> QUICKBUF_MESSAGE = ThreadLocal.withInitial(QuickbufSchema.Users::newInstance);

--- a/src/main/java/com/github/fabienrenaud/jjb/stream/Deserialization.java
+++ b/src/main/java/com/github/fabienrenaud/jjb/stream/Deserialization.java
@@ -13,7 +13,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
 import com.cedarsoftware.io.JsonIo;
-import com.cedarsoftware.io.ReadOptionsBuilder;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -93,12 +92,11 @@ public class Deserialization extends JsonBench {
     @Benchmark
     @Override
     public Object jsonio() {
-        
-        // returnAsNativeJsonObjects maps to old JsonWriter.USE_MAPS=true behavior, 
-        // see {@link JsonIo#getReadOptionsBuilder(java.util.Map)} and 
+        // returnAsNativeJsonObjects maps to old JsonWriter.USE_MAPS=true behavior,
+        // see {@link JsonIo#getReadOptionsBuilder(java.util.Map)} and
         // <a href="https://github.com/jdereg/json-io/blob/4.19.1/changelog.md">the v4.19 changelog</a>
         return JsonIo.toObjects(
-            JSON_SOURCE().nextInputStream(), new ReadOptionsBuilder().returnAsNativeJsonObjects().build(), null
+            JSON_SOURCE().nextInputStream(), JSON_SOURCE().provider().jsonioReadOptionsMaps(), null
         );
     }
 

--- a/src/main/java/com/github/fabienrenaud/jjb/stream/Deserialization.java
+++ b/src/main/java/com/github/fabienrenaud/jjb/stream/Deserialization.java
@@ -13,6 +13,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
 import com.cedarsoftware.io.JsonIo;
+import com.cedarsoftware.io.JsonObject;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -92,12 +93,14 @@ public class Deserialization extends JsonBench {
     @Benchmark
     @Override
     public Object jsonio() {
-        // returnAsNativeJsonObjects maps to old JsonWriter.USE_MAPS=true behavior,
-        // see {@link JsonIo#getReadOptionsBuilder(java.util.Map)} and
-        // <a href="https://github.com/jdereg/json-io/blob/4.19.1/changelog.md">the v4.19 changelog</a>
-        return JsonIo.toObjects(
-            JSON_SOURCE().nextInputStream(), JSON_SOURCE().provider().jsonioReadOptionsMaps(), null
-        );
+        // toMaps() returns the JsonObject (Map) graph directly via MapResolver,
+        // skipping the second-pass POJO field injection that toJava() does.
+        // ~45% faster on JsonPerformanceTest. The API handles Maps-mode option
+        // configuration internally via its own cache, so no options needed here.
+        // Explicit JsonObject target keeps the result as the native lite Map
+        // representation (the round-trip test in JsonBenchmark.test detects
+        // JsonObject and re-serializes it for verification).
+        return JsonIo.toMaps(JSON_SOURCE().nextInputStream()).asClass(JsonObject.class);
     }
 
     @Benchmark

--- a/src/main/java/com/github/fabienrenaud/jjb/stream/Serialization.java
+++ b/src/main/java/com/github/fabienrenaud/jjb/stream/Serialization.java
@@ -96,9 +96,9 @@ public class Serialization extends JsonBench {
     @Benchmark
     @Override
     public Object jsonio() {
-
-        // showTypeInfoNever maps to old TYPE=false behavior see {@link JsonIo#getWriteOptionsBuilder(java.util.Map)}
-        return JsonIo.toJson(JSON_SOURCE().nextPojo(), new WriteOptionsBuilder().showTypeInfoNever().build());
+        // standardJson() produces Jackson-compatible JSON: suppresses @type, @id/@ref,
+        // root type info; stringifies non-String map keys; emits ISO-8601 dates.
+        return JsonIo.toJson(JSON_SOURCE().nextPojo(), new WriteOptionsBuilder().standardJson().build());
     }
 
     @Benchmark

--- a/src/main/java/com/github/fabienrenaud/jjb/stream/Serialization.java
+++ b/src/main/java/com/github/fabienrenaud/jjb/stream/Serialization.java
@@ -5,7 +5,6 @@ import java.io.OutputStreamWriter;
 import java.io.Writer;
 
 import com.cedarsoftware.io.JsonIo;
-import com.cedarsoftware.io.WriteOptionsBuilder;
 import org.openjdk.jmh.annotations.Benchmark;
 
 import com.fasterxml.jackson.core.JsonGenerator;
@@ -98,7 +97,7 @@ public class Serialization extends JsonBench {
     public Object jsonio() {
         // standardJson() produces Jackson-compatible JSON: suppresses @type, @id/@ref,
         // root type info; stringifies non-String map keys; emits ISO-8601 dates.
-        return JsonIo.toJson(JSON_SOURCE().nextPojo(), new WriteOptionsBuilder().standardJson().build());
+        return JsonIo.toJson(JSON_SOURCE().nextPojo(), JSON_SOURCE().provider().jsonioWriteOptions());
     }
 
     @Benchmark

--- a/src/main/java/com/github/fabienrenaud/jjb/support/BenchSupport.java
+++ b/src/main/java/com/github/fabienrenaud/jjb/support/BenchSupport.java
@@ -52,7 +52,7 @@ public enum BenchSupport {
             new Libapi(Library.JAKARTAJSON),
             new Libapi(Library.FLEXJSON, Api.DATABIND),
             new Libapi(Library.FASTJSON, Api.DATABIND),
-            new Libapi(Library.JSONIO),
+            new Libapi(Library.JSONIO, Api.DATABIND),
             new Libapi(false, Library.BOON, Api.DATABIND),
             new Libapi(false, Library.JOHNZON, Api.DATABIND),
             new Libapi(false, Library.JSONSMART, Api.DATABIND),

--- a/src/main/java/com/github/fabienrenaud/jjb/support/BenchSupport.java
+++ b/src/main/java/com/github/fabienrenaud/jjb/support/BenchSupport.java
@@ -17,7 +17,7 @@ public enum BenchSupport {
         new Libapi(Library.JAKARTAJSON, Api.STREAM),
         new Libapi(Library.FLEXJSON, Api.DATABIND),
         new Libapi(Library.FASTJSON, Api.DATABIND),
-        new Libapi(Library.JSONIO, Api.STREAM),
+        new Libapi(Library.JSONIO, Api.DATABIND, Api.STREAM),
         new Libapi(Library.BOON, Api.DATABIND),
         new Libapi(Library.JOHNZON, Api.DATABIND),
         new Libapi(Library.JSONSMART, Api.DATABIND),

--- a/src/test/java/com/github/fabienrenaud/jjb/JsonBenchmark.java
+++ b/src/test/java/com/github/fabienrenaud/jjb/JsonBenchmark.java
@@ -36,7 +36,7 @@ public abstract class JsonBenchmark<T> {
         if (o instanceof Users || o instanceof Clients) {
             testPojo((T) o);
         } else if (o instanceof com.cedarsoftware.io.JsonObject) {
-            String v = com.cedarsoftware.io.JsonIo.toJson(o, new WriteOptionsBuilder().showTypeInfoNever().build());
+            String v = com.cedarsoftware.io.JsonIo.toJson(o, new WriteOptionsBuilder().standardJson().build());
             testString(v);
         } else if (o instanceof com.grack.nanojson.JsonObject) {
             String v = com.grack.nanojson.JsonWriter.string(o);


### PR DESCRIPTION
Adds DATABIND coverage for json-io (it was stream-only previously),
bumps the dependency 4.88.0 → 4.102.0, and corrects a benchmark-wiring
issue in the json-io `@Benchmark` methods.

## Benchmark-correctness fix (most important)

The previous `databind/Serialization.jsonio()`, `stream/Serialization.jsonio()`,
and `stream/Deserialization.jsonio()` constructed fresh
`WriteOptionsBuilder().standardJson().build()` (and equivalent
`ReadOptionsBuilder`) **inside the `@Benchmark` body**, paying the
options-build setup cost (load aliases, build writer maps, allocate the
immutable snapshot) on every iteration.

Effect on the published numbers: at 1KB DATABIND ser, json-io measured
**2,996 ops/s** — about **1,830× slower than Jackson**. Almost all of
that gap was benchmark wiring overhead, not json-io itself.

After moving the construction to a `private final` field on
`JsonProvider` (matching how every other library here — `jackson()`,
`gson()`, `genson()`, `yasson()`, `boon()`, `johnzon()`, `moshi()`,
`avajeJsonb*()`, etc. — is already wired), the same workload runs at
**1,288,107 ops/s** — about **1.76× slower than Jackson**. The
remaining gap is real json-io performance, not measurement artifact.

The new accessor on `JsonProvider`:

```java
WriteOptions jsonioWriteOptions();   // returns a private final, built once
```

`UsersJsonProvider` and `ClientsJsonProvider` each construct one
`WriteOptions` instance using `standardJson()` (json-io's
Jackson-compatible JSON preset: `showTypeInfoNever()`,
`cycleSupport=false`, `stringifyMapKeys=true`, ISO-8601 dates).

## Switch stream deser to non-deprecated `JsonIo.toMaps()`

`JsonIo.toObjects(InputStream, ReadOptions, Class)` was deprecated in
json-io 4.101.0 and is scheduled for removal in 5.0.0. The
`stream/Deserialization.jsonio()` method now calls
`JsonIo.toMaps(InputStream).asClass(JsonObject.class)`, which routes
through the same `MapResolver` path and manages Maps-mode options
internally via its own cache (no need to pass options).

Result type is materialized as `JsonObject` so the round-trip
verification in `JsonBenchmark.test()` recognizes it (the
`instanceof JsonObject` branch re-serializes via
`WriteOptionsBuilder().standardJson().build()` for parity-checking
against Jackson).

## Updated dependency: json-io 4.88.0 → 4.102.0

Two intermediate releases (4.101.0, 4.102.0) brought meaningful
performance work, including an adaptive shape cache in
`ObjectResolver.traverseFields` that reduces per-field HashMap-lookup
cost on arrays of homogeneous POJOs. Full release notes:
https://github.com/jdereg/json-io/blob/master/changelog.md

## Results

Measured locally on this PR's HEAD with the published config
(`-f 2 -wi 5 -i 10 -m 3 -t 3`, full 24-cell sweep). Ratio = Jackson
throughput / json-io throughput; **lower is better for json-io**.

| Workload | Cell | json-io 4.88.0<sup>1</sup> | json-io 4.102.0 (this PR) |
|---|---|---:|---:|
| USERS  | DB ser  1KB   | n/a (no DB coverage)         | **1.76×** |
| USERS  | DB ser  10KB  | n/a                          | **1.63×** |
| USERS  | DB ser  100KB | n/a                          | **1.53×** |
| USERS  | DB ser  1MB   | n/a                          | **1.42×** |
| USERS  | ST ser  1KB   | 122.6×                       | **1.88×** |
| USERS  | ST ser  10KB  | 22.8×                        | **1.59×** |
| USERS  | ST ser  100KB | 8.0×                         | **1.53×** |
| USERS  | ST ser  1MB   | 6.16×                        | **1.56×** |
| USERS  | DB deser 1KB  | n/a                          | (high variance, cell omitted) |
| USERS  | DB deser 10KB | n/a                          | **4.51×** |
| USERS  | DB deser 100KB| n/a                          | **4.72×** |
| USERS  | DB deser 1MB  | n/a                          | **4.85×** |
| USERS  | ST deser 1KB  | 70.0×                        | **1.99×** |
| USERS  | ST deser 10KB | 10.1×                        | **1.67×** |
| USERS  | ST deser 100KB| 3.63×                        | **1.91×** |
| USERS  | ST deser 1MB  | 3.23×                        | **2.08×** |
| CLIENTS| DB ser 1KB    | n/a                          | **2.05×** |
| CLIENTS| DB ser 10KB   | n/a                          | **1.58×** |
| CLIENTS| DB ser 100KB  | n/a                          | **1.51×** |
| CLIENTS| DB ser 1MB    | n/a                          | **1.47×** |
| CLIENTS| DB deser 1KB  | n/a                          | **2.40×** |
| CLIENTS| DB deser 10KB | n/a                          | **2.15×** |
| CLIENTS| DB deser 100KB| n/a                          | **2.01×** |
| CLIENTS| DB deser 1MB  | n/a                          | **2.04×** |

<sup>1</sup> 4.88.0 ratios sourced from `archive/raw-results-2026-02-28.md`.
DB = databind, ST = stream.

The 1KB DATABIND deser cell has high run-to-run variance (~78%
spread across paired same-state measurements) so single-run numbers
there are unreliable; intentionally omitted.

The remaining gap on USERS DATABIND deser (~4.5–4.9×) reflects
json-io's per-field reflective field injection vs Jackson's compile-
time codegen in databind. Closing it further is the focus of the
upcoming json-io 4.103.0+ work and would be the subject of a future
follow-up dependency-bump PR.

## Commits

```
6db3c4e   Step 1:  add json-io DATABIND coverage for USERS
4fa585e   Step 1b: switch json-io serialize options from showTypeInfoNever() to standardJson()
a6a349b   Step 2:  register Api.DATABIND for json-io in BenchSupport.CLIENTS
0965f50   Step 3:  bump json-io 4.88.0 → 4.101.0
1f56bf9   Cache json-io WriteOptions/ReadOptions on the provider; bump to 4.102.0
967a94c   Switch json-io stream deser to JsonIo.toMaps() (toObjects deprecated)
```
